### PR TITLE
justfile: rename lowercase cleanpython in pyproject.toml

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,13 +51,13 @@ MIN_COVERAGE := '100'
     echo "    just doc"
     echo
 
-# rename project and author
+# rename project and author (please use lowercase for project name)
 @rename project author:
     mv src/cleanpython src/{{project}}
     # replace string "Cleanpython" with {{project}} and "iacopy" with {{author}} in files
     sed -i "" -e s/cleanpython/"{{project}}"/g tests/test_app.py
     sed -i "" -e s/cleanpython/"{{project}}"/g tests/test_foobar.py
-    sed -i "" -e s/Cleanpython/"{{project}}"/g -e s/iacopy/"{{author}}"/g pyproject.toml
+    sed -i "" -e s/Cleanpython/"{{project}}"/g -e s/cleanpython/"{{project}}"/g -e s/iacopy/"{{author}}"/g pyproject.toml
     sed -i "" s/"Clean code with batteries included."/"Project description placeholder"/g pyproject.toml
     sed -i "" s/iacopy/"{{author}}"/g LICENSE
 


### PR DESCRIPTION
Add the suggestion about using the lowercase for the project name Fix #63