### PR TITLE
cloc: try to fix the push error

### DIFF
--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -31,3 +31,5 @@ jobs:
       with:
         commit_message: "Update line count"
         file_pattern: "lines_of_code.*"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Error to fix:

! [remote rejected] main -> main (protected branch hook declined)

Probably is due to the protection rule "pull request needed" (something like this).


Issue #67