### PR TITLE
justfile, pre-commit-hook: add black-hook recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -131,6 +131,10 @@ install-hooks:
     # install pre-push hook
     echo "just test" > .git/hooks/pre-push&&chmod +x .git/hooks/pre-push
 
+black-hook:
+    # ensures that all your commits contain Python code formatted according to Black’s rules.
+    cp pre-commit-black .git/hooks/pre-commit&&chmod +x .git/hooks/pre-commit
+
 # bootstrap your virtualenv (deprecated)
 setenv VIRTUALENV:
     @echo Create virtualenv and use it to install requirements

--- a/pre-commit-black
+++ b/pre-commit-black
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Run Black on all Python files
+files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+if [ -n "$files" ]; then
+  echo "Running Black on Python files..."
+  black $files
+  # Add the formatted files back to the staging area
+  git add $files
+fi


### PR DESCRIPTION
Install a pre-commit hook that launch black on files in the staging area.
This approach ensures that all your commits contain Python code formatted according to Black’s rules.

Issue #69